### PR TITLE
Nicer headings with code

### DIFF
--- a/source/builtins.rst
+++ b/source/builtins.rst
@@ -7,8 +7,8 @@ These changes are detailed in this section.
 
 .. _print-function:
 
-``print()``
-~~~~~~~~~~~
+The ``print()`` function
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_print``
 * Prevalence: Very Common
@@ -39,8 +39,8 @@ The recommended fixer will add the future import and rewrite all uses
 of ``print``.
 
 
-``input()``
-~~~~~~~~~~~
+Safe ``input()``
+~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_input_six``
 * Prevalence: Uncommon
@@ -68,8 +68,8 @@ it produces is really necessary.
 
 .. _file-builtin:
 
-``file()``
-~~~~~~~~~~
+Removed ``file()``
+~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_file`` (but see below)
 * Prevalence: Rare
@@ -108,8 +108,8 @@ that includes :class:`io.IOBase` and, under Python 2, ``file``::
     isinstance(f, file_types)
 
 
-``apply()``
-~~~~~~~~~~~
+Removed ``apply()``
+~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_apply`` (but see below)
 * Prevalence: Common
@@ -133,8 +133,8 @@ If the variable ``apply`` names a different function
 in some of your modules, revert the fixer's changes in that module.
 
 
-``reduce()``
-~~~~~~~~~~~~
+Moved ``reduce()``
+~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_reduce``
 * Prevalence: Uncommon
@@ -153,8 +153,8 @@ The recommended fixer will add this import automatically.
 
 .. _exec:
 
-``exec()``
-~~~~~~~~~~
+The ``exec()`` function
+~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_exec``
 * Prevalence: Rare
@@ -180,8 +180,8 @@ The recommended fixer will convert all uses of ``exec`` to the function-like
 syntax.
 
 
-``execfile()``
-~~~~~~~~~~~~~~
+Removed ``execfile()``
+~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: None recommended
 * Prevalence: Very rare
@@ -210,8 +210,8 @@ using it, as it doesn't close the file correctly.
 .. XXX: file an issue in python-modernize
 
 
-``reload()``
-~~~~~~~~~~~~
+Moved ``reload()``
+~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: None
 * Prevalence: Very rare
@@ -231,8 +231,8 @@ If your code uses ``reload()``, import it conditionally on Python 3::
 
 
 
-``intern()``
-~~~~~~~~~~~~
+Moved ``intern()``
+~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: None
 * Prevalence: Very rare
@@ -248,8 +248,8 @@ If your code uses ``intern()``, import it conditionally on Python 3::
         from sys import intern
 
 
-``coerce()``
-~~~~~~~~~~~~
+Removed ``coerce()``
+~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: None
 * Prevalence: Rare

--- a/source/core-obj-misc.rst
+++ b/source/core-obj-misc.rst
@@ -79,8 +79,8 @@ representation of an integer before, you'll need to change any code that
 relied on them.
 
 
-``__getslice__``, ``__setslice__``, ``__delslice__``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Old-style slicing: ``__getslice__``, ``__setslice__``, ``__delslice__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: None
 * Prevalence: Rare
@@ -145,8 +145,8 @@ would be::
                 raise TypeError('non-slice indexing not supported')
 
 
-``__bool__``
-~~~~~~~~~~~~
+Customizing truthiness: ``__bool__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: None
 * Prevalence: Common

--- a/source/etc.rst
+++ b/source/etc.rst
@@ -3,8 +3,8 @@ Other Changes
 
 XXX
 
-``buffer`` and ``memoryview``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Raw buffer protocol: ``buffer`` and ``memoryview``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Doctests
 ~~~~~~~~

--- a/source/iterators.rst
+++ b/source/iterators.rst
@@ -10,8 +10,8 @@ functions with a call to :func:`py3:list`. However, in most cases it is better
 to apply a more specific fix.
 
 
-``map()`` and ``filter()``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+New behavior of ``map()`` and ``filter()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixers <python-modernize>` (See caveat below):
 
@@ -126,8 +126,8 @@ are rebound to something else than the built-in functions.
 If your code does this, you'll need to do appropriate changes manually.
 
 
-``zip()``
-~~~~~~~~~
+New behavior of ``zip()``
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_zip`` (See caveat below)
 * Prevalence: Common
@@ -154,8 +154,8 @@ is rebound to something else than the built-in function.
 If your code does this, you'll need to do appropriate changes manually.
 
 
-``range()``
-~~~~~~~~~~~
+New behavior of ``range()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_xrange_six`` (See caveat below)
 * Prevalence: Common
@@ -198,8 +198,8 @@ function, the fixer will not work properly.
 In this case you'll need to do appropriate changes manually.
 
 
-``next()``
-~~~~~~~~~~
+New iteration protocol: ``next()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf libmodernize.fixes.fix_next`` (See caveat below)
 * Prevalence: Common

--- a/source/numbers.rst
+++ b/source/numbers.rst
@@ -117,8 +117,8 @@ The recommended fixer will do this.
 
 .. _long-literals:
 
-``L`` suffix not allowed in numeric literals
-............................................
+The ``L`` suffix not allowed in numeric literals
+................................................
 
 * :ref:`Fixer <python-modernize>`: ``python-modernize -wnf lib2to3.fixes.fix_numliterals`` (but see below)
 * Prevalence: Very common
@@ -139,8 +139,8 @@ If the specific type is important, you will need to refactor the code so that
 it does not rely on the distinction, as discussed above.
 
 
-``L`` suffix dropped from the representation
-............................................
+The ``L`` suffix dropped from the representation
+................................................
 
 * :ref:`Fixer <python-modernize>`: None
 * Prevalence: Rare

--- a/source/tools.rst
+++ b/source/tools.rst
@@ -8,8 +8,8 @@ Here is a survey of tools we recommend.
 
 .. _six:
 
-six
----
+Compatibility library: ``six``
+------------------------------
 
 When porting a large piece of software, it is desirable to support both
 Python 2 and Python 3 in the same codebase.
@@ -37,8 +37,8 @@ or outright copying relevant pieces of it into your code.
 
 .. _python-modernize:
 
-python-modernize
-----------------
+Automated fixer: ``python-modernize``
+-------------------------------------
 
 Some steps of the porting process are quite mechanical, and can be automated.
 These are best handled by the ``python-modernize`` tool – a code-to-code
@@ -77,8 +77,8 @@ This guide will provide the necessary background for each fixer as we
 go along.
 
 
-py3c
-----
+Compatibility headers and guide for C extensions: ``py3c``
+----------------------------------------------------------
 
 Some projects involve extension modules written in C/C++, or embed Python in
 a C/C++-based application.
@@ -102,8 +102,8 @@ For these, we have two pieces of advice:
   extensions: `py3c`_.
 
 
-pylint --py3k
--------------
+Automated checker: ``pylint --py3k``
+------------------------------------
 
 Pylint is a static code analyzer that can catch mistakes such as
 initialized variables, unused imports, and duplicated code.


### PR DESCRIPTION
- Makes headings that contain code look like headings.
- Show tool names as code, even in headings (#18)