### PR TITLE
Clarify intention of sentence on has_key/in

### DIFF
--- a/source/dicts.rst
+++ b/source/dicts.rst
@@ -27,7 +27,7 @@ you should use::
 Note that the recommended fixer replaces all calls to *any* ``has_key`` method;
 it does not check that its object is actually a dictionary.
 
-If you use a third-party non-dict-like class, it should implement ``in``
+If you use a third-party dict-like class, it should implement ``in``
 already.
 If not, complain to its author: it should have been added as part of adding
 Python 3 support.


### PR DESCRIPTION
I read "third-party non-dict-like class" as "a third party class that acts like a non-dictionary".

I'm pretty sure "third-party dict-like class" was meant (meaning a third-party class that acts like a dictionary).