### PR TITLE
Remove a confusing underscore

### DIFF
--- a/source/syntax.rst
+++ b/source/syntax.rst
@@ -91,12 +91,12 @@ The recommended fixer does a good job, though it doesn't catch the case where
 the name ``repr`` is redefined, as in::
 
     repr = None
-    print(`1+_2`)
+    print(`1+2`)
 
 which becomes::
 
     repr = None
-    print(repr(1+_2))
+    print(repr(1+2))
 
 Re-defining built-in functions is usually considered bad style, but it never
 hurts to check if the code does it.


### PR DESCRIPTION
I have no idea why it is there, yet I had to think about it.

If there is an actual reason please tell me and close this.