### PR TITLE
Fix the tests to work with modernize 0.6.1

### DIFF
--- a/test_portingdb/test_fixer_library.py
+++ b/test_portingdb/test_fixer_library.py
@@ -20,7 +20,10 @@ def fixer_names():
     # use subprocess -- modernize doesn't have public fixer list API
     proc = subprocess.run([sys.executable, '-m', 'modernize', '-l'],
                           stdout=subprocess.PIPE, encoding='ascii', check=True)
-    lines = proc.stdout.splitlines()
+
+    # In modernize 0.6.1, the output has changed to list additional information
+    # This takes the first part only and works with older modernize as well
+    lines = [l.strip().split()[0] for l in proc.stdout.splitlines() if l]
 
     # first line is a header, all others should be fixers
     assert not FIXER_RE.fullmatch(lines[0])


### PR DESCRIPTION
modernize 0.6 had:

```console
$ python -m modernize -l
Available transformations for the -f/--fix option:
lib2to3.fixes.fix_apply
...
(+empty line at the end)
```

modernize 0.6.1 has:

```console
$ python -m modernize -l
Available transformations for the -f/--fix and -x/--nofix options:
    lib2to3.fixes.fix_apply  (apply)
...
```