### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/source/builtins.rst
+++ b/source/builtins.rst
@@ -105,12 +105,11 @@ aren't of the ``file`` type.
 If type-checking for files is necessary, we recommend using a tuple of types
 that includes :class:`io.IOBase` and, under Python 2, ``file``::
 
-    import six
     import io
 
-    if six.PY2:
+    try:
         file_types = file, io.IOBase
-    else:
+    except NameError:
         file_types = (io.IOBase,)
 
     ...
@@ -263,9 +262,9 @@ Python 2.6 and below didn't have an ``importlib`` module.
 
 If your code uses ``reload()``, import it conditionally on Python 3::
 
-    import six
-
-    if not six.PY2:
+    try:
+        reload
+    except NameError:
         from importlib import reload
 
 
@@ -283,9 +282,9 @@ In Python 3, it is moved to the ``sys`` module.
 
 If your code uses ``intern()``, import it conditionally on Python 3::
 
-    import six
-
-    if not six.PY2:
+    try:
+        intern
+    except NameError:
         from sys import intern
 
 

--- a/source/builtins.rst
+++ b/source/builtins.rst
@@ -108,8 +108,10 @@ that includes :class:`io.IOBase` and, under Python 2, ``file``::
     import io
 
     try:
+        # Python 2: "file" is built-in
         file_types = file, io.IOBase
     except NameError:
+        # Python 3: "file" fully replased with IOBase
         file_types = (io.IOBase,)
 
     ...
@@ -260,9 +262,11 @@ In Python 3, it is moved to the ``importlib`` module.
 Python 2.7 included an ``importlib`` module, but without a ``reload`` function.
 Python 2.6 and below didn't have an ``importlib`` module.
 
-If your code uses ``reload()``, import it conditionally on Python 3::
+If your code uses ``reload()``, import it conditionally if it doesn't exist
+(using `feature detection`_)::
 
     try:
+        # Python 2: "reload" is built-in
         reload
     except NameError:
         from importlib import reload
@@ -280,9 +284,11 @@ Moved ``intern()``
 The :func:`~sys.intern` function was built-in in Python 2.
 In Python 3, it is moved to the ``sys`` module.
 
-If your code uses ``intern()``, import it conditionally on Python 3::
+If your code uses ``intern()``, import it conditionally if it doesn't exist
+(using `feature detection`_)::
 
     try:
+        # Python 2: "intern" is built-in
         intern
     except NameError:
         from sys import intern
@@ -306,3 +312,9 @@ If any of your classes defines the special method ``__coerce__``,
 remove that as well, and test that the removal did not break semantics.
 
 .. XXX: I've never seen serious use of ``coerce``, so the advice is limited.
+
+
+.. Common links
+   ------------
+
+.. _feature detection: https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection

--- a/source/strings.rst
+++ b/source/strings.rst
@@ -140,7 +140,10 @@ For better readability, we recommend using ``unicode``,
 which is unambiguous and clear, but it needs to be introduced with the
 following code at the beginning of a file::
 
-    if not six.PY2:
+    try:
+        # Python 2: "unicode" is built-in
+        unicode
+    except NameError:
         unicode = str
 
 


### PR DESCRIPTION
Follow the Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).  These solutions work even for projects that do not adopt the __six__ module.