### PR TITLE
Test future imports

### DIFF
--- a/test_portingguide/test_future_imports.py
+++ b/test_portingguide/test_future_imports.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import subprocess
+import re
+import sys
+
+import pytest
+
+basepath = Path(__file__).parent.parent / 'source'
+all_rst_files = [str(p.relative_to(basepath))
+                 for p in basepath.glob('**/*.rst')]
+
+# All future imports mentioned
+FUTURE_RE = re.compile(r'from __future__ import [^\s`]+')
+
+
+def try_import(line):
+    cp = subprocess.run([sys.executable, '-c', line])
+    return cp.returncode
+
+
+@pytest.mark.parametrize('filename', all_rst_files)
+def test_future_imports_work(filename):
+    """Test that all mentioned future imports work"""
+    path = basepath / filename
+    with path.open() as f:
+        for lineno, line in enumerate(f, start=1):
+            for match in FUTURE_RE.finditer(line):
+                found_text = match.group(0)
+                print(f'{filename}:{lineno}:{found_text}')
+                assert try_import(found_text) == 0


### PR DESCRIPTION
See also https://github.com/fedora-python/portingguide/pull/48

This tests the imports on Python 3, not Python 2, but at least the imports we care about should exit cleanly on Python 3.

Example failure:

```pytest
...
=================================== FAILURES ===================================
____________________ test_future_imports_work[imports.rst] _____________________

filename = 'imports.rst'

    @pytest.mark.parametrize('filename', all_rst_files)
    def test_future_imports_work(filename):
        """Test that all mentioned future imports work"""
        path = basepath / filename
        with path.open() as f:
            for lineno, line in enumerate(f, start=1):
                for match in FUTURE_RE.finditer(line):
                    found_text = match.group(0)
                    print(f'{filename}:{lineno}:{found_text}')
>                   assert try_import(found_text) == 0
E                   assert 1 == 0
E                     -1
E                     +0

test_portingguide/test_future_imports.py:30: AssertionError
----------------------------- Captured stdout call -----------------------------
imports.rst:15:from __future__ import absolute_imports
----------------------------- Captured stderr call -----------------------------
  File "<string>", line 1
SyntaxError: future feature absolute_imports is not defined
===================== 1 failed, 33 passed in 0.16 seconds ======================

```

cc @jefftrull  